### PR TITLE
fix: reliable parallel pipeline for unattended agent use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+
 # Demo/test output
 demo-output/
 output/

--- a/design_scout/cache.py
+++ b/design_scout/cache.py
@@ -1,0 +1,58 @@
+"""Simple file-based cache to avoid re-processing the same URLs."""
+
+import json
+from pathlib import Path
+from typing import Dict, Optional, Any
+
+
+CACHE_FILENAME = ".design_scout_cache.json"
+
+
+class Cache:
+    """File-based cache for screenshots and scores.
+
+    Stores results keyed by normalized URL so repeated runs
+    skip already-processed sites.
+    """
+
+    def __init__(self, output_dir: str):
+        self.path = Path(output_dir) / CACHE_FILENAME
+        self.data: Dict[str, Any] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            try:
+                self.data = json.loads(self.path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                self.data = {}
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            json.dumps(self.data, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    # -- screenshots --
+    def get_screenshots(self, url: str) -> Optional[Dict[str, str]]:
+        """Return cached screenshot paths if they still exist on disk."""
+        entry = self.data.get(url, {})
+        shots = entry.get("screenshots")
+        if not shots:
+            return None
+        # Verify files still exist
+        for path in shots.values():
+            if not Path(path).exists():
+                return None
+        return shots
+
+    def set_screenshots(self, url: str, screenshots: Dict[str, str]) -> None:
+        self.data.setdefault(url, {})["screenshots"] = screenshots
+
+    # -- scores --
+    def get_score(self, url: str) -> Optional[Dict]:
+        return self.data.get(url, {}).get("score")
+
+    def set_score(self, url: str, score: Dict) -> None:
+        self.data.setdefault(url, {})["score"] = score

--- a/design_scout/cli.py
+++ b/design_scout/cli.py
@@ -1,21 +1,22 @@
-"""Design Scout CLI - 全自動設計靈感搜集工具
+"""Design Scout CLI — fully automated design inspiration collector.
 
-Flow (按照 spec):
-1. 搜尋 30-40 個候選 URL（Google + Awwwards + Dribbble + SiteInspire）
-2. 全部截圖（Desktop 1440px + Mobile 390px）
-3. AI 評分全部截圖（Vision 0-100 + 評語）
-4. 排序取 Top N
-5. 輸出 HTML 報告 + JSON 資料
+Flow:
+1. Search 4 sources in parallel  (or read a URL list file)
+2. Deduplicate & health-check
+3. Screenshot all URLs (desktop + mobile) — skip cached
+4. AI-score all screenshots in parallel  — skip cached
+5. Rank & output HTML + JSON report
 """
 
 import asyncio
 import sys
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import click
 
 from design_scout import __version__
+from design_scout.cache import Cache
 from design_scout.search.aggregator import search_async, TARGET_URLS
 from design_scout.screenshot.capture import capture_batch
 from design_scout.screenshot.browser import BrowserManager
@@ -23,146 +24,217 @@ from design_scout.scoring.evaluator import evaluate
 from design_scout.report.generator import generate_html, generate_json, format_result
 
 
-def print_progress(message: str, emoji: str = "🔄") -> None:
-    """Print progress message."""
-    click.echo(f"{emoji} {message}")
+def _echo(msg: str, **kw) -> None:
+    click.echo(click.style(msg, **kw))
 
 
 @click.command()
-@click.argument("keyword")
+@click.argument("keyword", required=False, default=None)
+@click.option("--urls", "-u", type=click.Path(exists=True), help="Text file with one URL per line (skips search)")
 @click.option("--count", "-c", default=5, help="Number of TOP results to return (default: 5)")
 @click.option("--output", "-o", default="./output", help="Output directory (default: ./output)")
 @click.option("--no-score", is_flag=True, help="Skip AI scoring (faster, no API needed)")
-@click.option("--search-count", "-s", default=40, help="Number of URLs to search (default: 40)")
+@click.option("--no-cache", is_flag=True, help="Ignore cache, re-process everything")
+@click.option("--search-count", "-s", default=TARGET_URLS, help=f"Target search URLs (default: {TARGET_URLS})")
 @click.version_option(version=__version__, prog_name="design-scout")
-def main(keyword: str, count: int, output: str, no_score: bool, search_count: int) -> None:
+def main(
+    keyword: Optional[str],
+    urls: Optional[str],
+    count: int,
+    output: str,
+    no_score: bool,
+    no_cache: bool,
+    search_count: int,
+) -> None:
     """Search for design inspiration based on KEYWORD.
-    
-    Searches 30-40 URLs, screenshots ALL of them, scores ALL with AI,
-    then returns the TOP N results sorted by score.
-    
-    Example: design-scout "fintech dashboard"
+
+    Two input modes:
+
+      design-scout "fintech dashboard"          # auto-search
+
+      design-scout --urls sites.txt             # provide URL list
     """
-    click.echo(click.style(f"\n🎨 Design Scout v{__version__}", fg="cyan", bold=True))
-    click.echo(click.style(f'   Searching for: "{keyword}"', fg="white"))
-    click.echo(click.style(f'   Will search {search_count} URLs, return Top {count}\n', fg="white"))
-    
+    if not keyword and not urls:
+        click.echo("Error: provide a KEYWORD or --urls file.")
+        raise SystemExit(1)
+
+    _echo(f"\n🎨 Design Scout v{__version__}", fg="cyan", bold=True)
+    if keyword:
+        _echo(f'   Keyword: "{keyword}"', fg="white")
+    if urls:
+        _echo(f"   URL list: {urls}", fg="white")
+    _echo(f"   Top {count} results → {output}\n", fg="white")
+
     try:
-        asyncio.run(run_scout(keyword, count, output, no_score, search_count))
+        asyncio.run(run_scout(
+            keyword=keyword,
+            urls_file=urls,
+            top_n=count,
+            output=output,
+            no_score=no_score,
+            no_cache=no_cache,
+            search_count=search_count,
+        ))
     except KeyboardInterrupt:
         click.echo("\n⛔ Cancelled by user")
         sys.exit(1)
     except Exception as e:
-        click.echo(click.style(f"\n❌ Error: {e}", fg="red"))
+        _echo(f"\n❌ Error: {e}", fg="red")
         import traceback
         traceback.print_exc()
         sys.exit(1)
 
 
-async def run_scout(keyword: str, top_n: int, output: str, no_score: bool, search_count: int) -> None:
-    """Run the design scout pipeline.
-    
-    按照 spec 的完整流程：
-    1. 搜尋 30-40 個 URL（4 個來源）
-    2. 全部截圖
-    3. 全部評分
-    4. 排序取 Top N
-    """
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+async def run_scout(
+    *,
+    keyword: Optional[str],
+    urls_file: Optional[str],
+    top_n: int,
+    output: str,
+    no_score: bool,
+    no_cache: bool,
+    search_count: int,
+) -> None:
     output_path = Path(output)
     output_path.mkdir(parents=True, exist_ok=True)
-    
-    # ============================================
-    # Step 1: 搜尋候選 (30-40 URLs from 4 sources)
-    # ============================================
-    print_progress(f"Step 1: 搜尋候選 URL（目標 {search_count} 個）", "🔍")
-    urls = await search_async(keyword, search_count)
-    
-    if not urls:
-        click.echo(click.style("No URLs found. Try different keywords.", fg="yellow"))
+
+    cache = Cache(str(output_path)) if not no_cache else None
+
+    # ── Step 1: Collect URLs ──────────────────────────────────────────
+    if urls_file:
+        _echo("Step 1: 讀取 URL 清單", fg="white")
+        url_list = _read_url_file(urls_file)
+        _echo(f"   ✓ {len(url_list)} URLs from file", fg="green")
+    else:
+        _echo(f"Step 1: 並行搜尋（目標 {search_count} URLs）", fg="white")
+        url_list, report = await search_async(keyword, search_count)
+        click.echo(report.summary())
+        if report.all_failed:
+            _echo("   ✗ 所有搜尋來源都失敗，請檢查網路連線。", fg="red")
+            return
+        _echo(f"   ✓ 取得 {len(url_list)} unique URLs", fg="green")
+
+    if not url_list:
+        _echo("沒有找到 URL，請換個關鍵字試試。", fg="yellow")
         return
-    
-    click.echo(click.style(f"   ✓ 找到 {len(urls)} 個候選 URL", fg="green"))
-    
-    # ============================================
-    # Step 2: 批量截圖 (ALL URLs, Desktop + Mobile)
-    # ============================================
-    print_progress(f"Step 2: 批量截圖（{len(urls)} 個 URL × 2 viewports）", "📸")
+
+    # ── Step 2: Screenshot (with cache) ───────────────────────────────
     screenshots_dir = output_path / "screenshots"
-    
-    # Screenshot ALL URLs, not just top_n
-    screenshots = await capture_batch(urls, str(screenshots_dir), concurrency=5, timeout=30)
-    
-    successful = {k: v for k, v in screenshots.items() if v is not None}
-    failed = len(screenshots) - len(successful)
-    
-    click.echo(click.style(f"   ✓ 成功截圖 {len(successful)}/{len(screenshots)} 個網站", fg="green"))
-    if failed > 0:
-        click.echo(click.style(f"   ⚠ {failed} 個網站截圖失敗（timeout 或載入錯誤）", fg="yellow"))
-    
-    if not successful:
-        click.echo(click.style("No screenshots captured. Check network connection.", fg="yellow"))
+    urls_to_capture: List[str] = []
+    cached_shots: Dict[str, Dict[str, str]] = {}
+
+    for url in url_list:
+        cached = cache.get_screenshots(url) if cache else None
+        if cached:
+            cached_shots[url] = cached
+        else:
+            urls_to_capture.append(url)
+
+    total = len(url_list)
+    from_cache = len(cached_shots)
+    to_capture = len(urls_to_capture)
+
+    _echo(f"Step 2: 截圖（{total} URLs — {from_cache} cached, {to_capture} new）", fg="white")
+
+    new_shots: Dict[str, Optional[Dict[str, str]]] = {}
+    if urls_to_capture:
+        new_shots = await capture_batch(urls_to_capture, str(screenshots_dir), concurrency=5, timeout=30)
+        # Update cache
+        for url, shots in new_shots.items():
+            if shots and cache:
+                cache.set_screenshots(url, shots)
+
+    # Merge
+    all_shots: Dict[str, Dict[str, str]] = {**cached_shots}
+    for url, shots in new_shots.items():
+        if shots:
+            all_shots[url] = shots
+
+    success = len(all_shots)
+    failed = total - success
+    _echo(f"   ✓ 截圖成功 {success}/{total}", fg="green")
+    if failed:
+        _echo(f"   ⚠ {failed} 個失敗（timeout / 載入錯誤）", fg="yellow")
+
+    if not all_shots:
+        _echo("沒有截圖成功。請檢查網路連線。", fg="yellow")
         return
-    
-    # ============================================
-    # Step 3: AI 評分 (ALL screenshots)
-    # ============================================
+
+    # ── Step 3: AI Scoring (parallel, with cache) ─────────────────────
     results: List[Dict[str, Any]] = []
-    
+
     if no_score:
-        print_progress("Step 3: 跳過 AI 評分（--no-score）", "⏭️")
-        for url, shots in successful.items():
+        _echo("Step 3: 跳過 AI 評分（--no-score）", fg="white")
+        for url, shots in all_shots.items():
             results.append(format_result(url, shots, None))
     else:
-        print_progress(f"Step 3: AI 評分（{len(successful)} 組截圖）", "🤖")
-        
-        scored_count = 0
-        for url, shots in successful.items():
-            # Evaluate desktop screenshot (primary)
+        _echo(f"Step 3: 並行 AI 評分（{len(all_shots)} 組截圖）", fg="white")
+
+        async def _score_one(url: str, shots: Dict[str, str]) -> Dict[str, Any]:
+            # Check cache first
+            if cache:
+                cached_score = cache.get_score(url)
+                if cached_score:
+                    return format_result(url, shots, cached_score)
+
             evaluation = None
-            if shots.get('desktop'):
-                evaluation = await evaluate(shots['desktop'])
-            
-            results.append(format_result(url, shots, evaluation))
-            
-            scored_count += 1
-            score = evaluation.get('total_score', '?') if evaluation else '?'
-            # Progress indicator
-            if scored_count % 5 == 0 or scored_count == len(successful):
-                click.echo(f"   評分進度: {scored_count}/{len(successful)}")
-        
-        click.echo(click.style(f"   ✓ 完成 {scored_count} 個網站評分", fg="green"))
-    
-    # ============================================
-    # Step 4: 排序取 Top N
-    # ============================================
-    print_progress(f"Step 4: 排序取 Top {top_n}", "📊")
-    
-    # Sort by score descending
-    sorted_results = sorted(results, key=lambda x: x.get('score', 0), reverse=True)
+            desktop = shots.get("desktop")
+            if desktop:
+                evaluation = await evaluate(desktop)
+                if evaluation and cache:
+                    cache.set_score(url, evaluation)
+            return format_result(url, shots, evaluation)
+
+        tasks = [_score_one(url, shots) for url, shots in all_shots.items()]
+        results = await asyncio.gather(*tasks)
+
+        scored = sum(1 for r in results if r.get("score", 0) > 0)
+        _echo(f"   ✓ {scored}/{len(results)} 有評分", fg="green")
+
+    # Save cache
+    if cache:
+        cache.save()
+
+    # ── Step 4: Rank ──────────────────────────────────────────────────
+    _echo(f"Step 4: 排序取 Top {top_n}", fg="white")
+    sorted_results = sorted(results, key=lambda x: x.get("score", 0), reverse=True)
     top_results = sorted_results[:top_n]
-    
-    click.echo(f"   Top {top_n} 分數範圍: {top_results[-1]['score']}-{top_results[0]['score']}" if top_results and top_results[0].get('score') else "   （無評分）")
-    
-    # ============================================
-    # Step 5: 輸出報告 (HTML + JSON)
-    # ============================================
-    print_progress("Step 5: 生成報告", "📝")
-    
-    html_path = generate_html(top_results, str(output_path), keyword)
-    json_path = generate_json(sorted_results, str(output_path), keyword)  # JSON 包含全部結果
-    
-    click.echo(f"   HTML 報告（Top {top_n}）: {html_path}")
-    click.echo(f"   JSON 資料（全部 {len(sorted_results)}）: {json_path}")
-    
-    # ============================================
-    # Summary
-    # ============================================
-    click.echo(click.style(f"\n✅ 完成！", fg="green", bold=True))
-    click.echo(f"   搜尋: {len(urls)} URLs")
-    click.echo(f"   截圖: {len(successful)} 成功")
-    click.echo(f"   評分: {len(results)} 個")
-    click.echo(f"   輸出: Top {top_n}")
+
+    if top_results and top_results[0].get("score"):
+        lo = top_results[-1]["score"]
+        hi = top_results[0]["score"]
+        click.echo(f"   分數範圍: {lo}–{hi}")
+
+    # ── Step 5: Report ────────────────────────────────────────────────
+    _echo("Step 5: 生成報告", fg="white")
+    display_keyword = keyword or "URL list"
+    html_path = generate_html(top_results, str(output_path), display_keyword)
+    json_path = generate_json(sorted_results, str(output_path), display_keyword)
+
+    click.echo(f"   HTML（Top {top_n}）: {html_path}")
+    click.echo(f"   JSON（全部 {len(sorted_results)}）: {json_path}")
+
+    # ── Summary ───────────────────────────────────────────────────────
+    _echo(f"\n✅ 完成！", fg="green", bold=True)
+    click.echo(f"   URLs:  {total}")
+    click.echo(f"   截圖:  {success}")
+    click.echo(f"   評分:  {len(results)}")
+    click.echo(f"   輸出:  Top {top_n}")
     click.echo(f"\n   👉 open {html_path}\n")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read_url_file(path: str) -> List[str]:
+    """Read a text file with one URL per line."""
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    return [line.strip() for line in lines if line.strip() and line.strip().startswith("http")]
 
 
 if __name__ == "__main__":

--- a/design_scout/screenshot/capture.py
+++ b/design_scout/screenshot/capture.py
@@ -1,7 +1,6 @@
-"""Screenshot capture functionality"""
+"""Screenshot capture — parallel batch capture with retry."""
 
 import asyncio
-import os
 from pathlib import Path
 from typing import Dict, Optional, List
 from urllib.parse import urlparse
@@ -11,154 +10,105 @@ from .browser import BrowserManager
 
 # Viewport configurations
 VIEWPORTS = {
-    'desktop': {'width': 1440, 'height': 900},
-    'mobile': {'width': 390, 'height': 844},
+    "desktop": {"width": 1440, "height": 900},
+    "mobile": {"width": 390, "height": 844},
 }
+
+MAX_RETRIES = 2
 
 
 async def capture(url: str, output_dir: str, timeout: int = 30) -> Optional[Dict[str, str]]:
-    """Capture screenshots of a URL in both desktop and mobile viewports.
-    
-    Args:
-        url: URL to screenshot
-        output_dir: Directory to save screenshots
-        timeout: Page load timeout in seconds
-        
-    Returns:
-        Dict with 'desktop' and 'mobile' screenshot paths, or None if failed
+    """Capture desktop + mobile screenshots for *url*.
+
+    Returns ``{"desktop": path, "mobile": path}`` or ``None`` on failure.
     """
-    # Create output directory
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
-    
-    # Generate filename from URL
     filename_base = url_to_filename(url)
-    
-    results = {}
-    
+
+    results: Dict[str, str] = {}
     for device, viewport in VIEWPORTS.items():
-        try:
-            screenshot_path = await capture_single(
-                url=url,
-                viewport=viewport,
-                output_path=output_path / f"{filename_base}_{device}.png",
-                timeout=timeout
-            )
-            if screenshot_path:
-                results[device] = str(screenshot_path)
-        except Exception as e:
-            print(f"Error capturing {device} screenshot for {url}: {e}")
-    
-    # Return None if no screenshots were captured
-    if not results:
-        return None
-    
-    return results
+        path = output_path / f"{filename_base}_{device}.png"
+        screenshot = await _capture_single(url, viewport, path, timeout)
+        if screenshot:
+            results[device] = str(screenshot)
+
+    return results or None
 
 
-async def capture_single(
-    url: str, 
-    viewport: dict, 
+async def _capture_single(
+    url: str,
+    viewport: dict,
     output_path: Path,
-    timeout: int = 30
+    timeout: int = 30,
 ) -> Optional[Path]:
-    """Capture a single screenshot.
-    
-    Args:
-        url: URL to screenshot
-        viewport: Viewport dimensions
-        output_path: Path to save screenshot
-        timeout: Timeout in seconds
-        
-    Returns:
-        Path to screenshot or None if failed
-    """
-    context = None
-    page = None
-    
-    try:
-        context = await BrowserManager.new_context(viewport)
-        page = await context.new_page()
-        
-        # Navigate with timeout
-        await page.goto(url, wait_until='networkidle', timeout=timeout * 1000)
-        
-        # Wait a bit for any animations/lazy loading
-        await asyncio.sleep(1)
-        
-        # Take screenshot
-        await page.screenshot(
-            path=str(output_path),
-            full_page=False,  # Just viewport, not full page
-            type='png'
-        )
-        
-        return output_path
-        
-    except Exception as e:
-        print(f"Screenshot failed for {url}: {e}")
-        return None
-        
-    finally:
-        if page:
-            await page.close()
-        if context:
-            await context.close()
+    """Capture one screenshot with retry logic."""
+    for attempt in range(1, MAX_RETRIES + 1):
+        context = None
+        page = None
+        try:
+            context = await BrowserManager.new_context(viewport)
+            page = await context.new_page()
+
+            # domcontentloaded is faster & more reliable than networkidle
+            await page.goto(url, wait_until="domcontentloaded", timeout=timeout * 1000)
+
+            # Small pause for late-rendering elements / fonts
+            await asyncio.sleep(1)
+
+            await page.screenshot(path=str(output_path), full_page=False, type="png")
+            return output_path
+
+        except Exception as e:
+            if attempt < MAX_RETRIES:
+                await asyncio.sleep(1)  # brief pause before retry
+            else:
+                print(f"Screenshot failed for {url} after {MAX_RETRIES} attempts: {e}")
+                return None
+        finally:
+            if page:
+                await page.close()
+            if context:
+                await context.close()
+
+    return None  # unreachable, but keeps type checkers happy
 
 
 async def capture_batch(
-    urls: List[str], 
-    output_dir: str, 
-    concurrency: int = 3,
-    timeout: int = 30
+    urls: List[str],
+    output_dir: str,
+    concurrency: int = 5,
+    timeout: int = 30,
 ) -> Dict[str, Optional[Dict[str, str]]]:
-    """Capture screenshots for multiple URLs in parallel.
-    
-    Args:
-        urls: List of URLs to screenshot
-        output_dir: Directory to save screenshots
-        concurrency: Max concurrent captures
-        timeout: Page load timeout per URL
-        
-    Returns:
-        Dict mapping URL to screenshot results
+    """Capture screenshots for many URLs in parallel.
+
+    Uses a semaphore to limit concurrency so we don't overwhelm the browser.
     """
     semaphore = asyncio.Semaphore(concurrency)
-    
-    async def capture_with_limit(url: str) -> tuple:
+
+    async def _limited(url: str) -> tuple:
         async with semaphore:
             result = await capture(url, output_dir, timeout)
             return (url, result)
-    
-    tasks = [capture_with_limit(url) for url in urls]
+
+    tasks = [_limited(u) for u in urls]
     results = await asyncio.gather(*tasks, return_exceptions=True)
-    
-    output = {}
-    for result in results:
-        if isinstance(result, tuple):
-            url, screenshots = result
-            output[url] = screenshots
-        # Ignore exceptions, just skip failed URLs
-    
-    # Cleanup browser after batch
+
+    output: Dict[str, Optional[Dict[str, str]]] = {}
+    for r in results:
+        if isinstance(r, tuple):
+            url, shots = r
+            output[url] = shots
+        # exceptions are silently skipped (already printed inside capture)
+
     await BrowserManager.close()
-    
     return output
 
 
 def url_to_filename(url: str) -> str:
-    """Convert URL to safe filename."""
+    """Convert URL to a filesystem-safe filename."""
     parsed = urlparse(url)
-    
-    # Use domain + path
     name = parsed.netloc + parsed.path
-    
-    # Remove/replace unsafe characters
-    for char in ['/', '\\', ':', '*', '?', '"', '<', '>', '|', '.']:
-        name = name.replace(char, '_')
-    
-    # Limit length
-    if len(name) > 100:
-        name = name[:100]
-    
-    return name.strip('_')
+    for ch in ["/", "\\", ":", "*", "?", '"', "<", ">", "|", "."]:
+        name = name.replace(ch, "_")
+    return name.strip("_")[:100]

--- a/design_scout/search/aggregator.py
+++ b/design_scout/search/aggregator.py
@@ -1,16 +1,15 @@
-"""Search aggregator - combines multiple sources for competitor landing page research
+"""Search aggregator - parallel multi-source search with health reporting.
 
-Sources (updated 2026-03-05):
-- DuckDuckGo (25) - General web search, main source
-- Product Hunt (15) - Trending products & startups
-- Landingfolio (10) - Curated landing pages
-- Lapa.ninja (10) - Landing page gallery
-
-Focus: Real operating websites for competitive research
+Sources:
+- DuckDuckGo  — General web search (httpx, reliable)
+- Product Hunt — Trending products (Playwright)
+- Landingfolio — Curated landing pages (Playwright)
+- Lapa.ninja   — Landing page gallery (Playwright)
 """
 
 import asyncio
-from typing import List
+from dataclasses import dataclass, field
+from typing import List, Dict
 from urllib.parse import urlparse
 
 from .duckduckgo import search_duckduckgo
@@ -19,125 +18,119 @@ from .landingfolio import search_landingfolio
 from .lapa import search_lapa
 
 
-# Target: 40-60 unique URLs from all sources
-TARGET_URLS = 50
-
-# Source quotas
+# Source quotas (how many URLs to request from each source)
 DDG_COUNT = 25
 PH_COUNT = 15
 LF_COUNT = 10
 LAPA_COUNT = 10
 
+TARGET_URLS = DDG_COUNT + PH_COUNT + LF_COUNT + LAPA_COUNT
 
-def search(keyword: str, count: int = TARGET_URLS) -> List[str]:
-    """Synchronous wrapper for async search (for non-async callers).
-    
-    Combines results from multiple sources, deduplicates, and normalizes URLs.
-    Returns up to `count` unique URLs for competitive research.
-    """
+
+@dataclass
+class SourceResult:
+    name: str
+    urls: List[str] = field(default_factory=list)
+    error: str = ""
+    ok: bool = True
+
+
+@dataclass
+class SearchReport:
+    """Health report for a search run."""
+    sources: List[SourceResult] = field(default_factory=list)
+    total_before_dedup: int = 0
+    total_after_dedup: int = 0
+
+    @property
+    def all_failed(self) -> bool:
+        return all(not s.ok or len(s.urls) == 0 for s in self.sources)
+
+    def summary(self) -> str:
+        lines = []
+        for s in self.sources:
+            status = f"✓ {len(s.urls)} URLs" if s.ok and s.urls else f"✗ {s.error or '0 URLs'}"
+            lines.append(f"   {s.name:15s} {status}")
+        lines.append(f"   {'─' * 30}")
+        lines.append(f"   Before dedup: {self.total_before_dedup}")
+        lines.append(f"   After dedup:  {self.total_after_dedup}")
+        return "\n".join(lines)
+
+
+def search(keyword: str, count: int = TARGET_URLS) -> tuple[List[str], SearchReport]:
+    """Synchronous wrapper."""
     return asyncio.run(search_async(keyword, count))
 
 
-async def search_async(keyword: str, count: int = TARGET_URLS) -> List[str]:
-    """Search multiple sources for competitor landing pages.
-    
-    Sources:
-    - DuckDuckGo (~25 URLs) - Primary source
-    - Product Hunt (~15 URLs) - Trending products
-    - Landingfolio (~10 URLs) - Curated landing pages
-    - Lapa.ninja (~10 URLs) - Landing page gallery
-    
-    After deduplication, returns 40-60 unique URLs.
-    
-    Args:
-        keyword: Search term (e.g., "fintech dashboard")
-        count: Target number of URLs (default: 50)
-        
-    Returns:
-        List of unique, normalized URLs
-    """
-    print(f"   Searching DuckDuckGo...")
-    ddg_results = await search_duckduckgo(keyword, DDG_COUNT)
-    print(f"   → DuckDuckGo: {len(ddg_results)} URLs")
-    
-    print(f"   Searching Product Hunt...")
-    ph_results = await search_producthunt(keyword, PH_COUNT)
-    print(f"   → Product Hunt: {len(ph_results)} URLs")
-    
-    print(f"   Searching Landingfolio...")
-    landingfolio_results = await search_landingfolio(keyword, LF_COUNT)
-    print(f"   → Landingfolio: {len(landingfolio_results)} URLs")
-    
-    print(f"   Searching Lapa.ninja...")
-    lapa_results = await search_lapa(keyword, LAPA_COUNT)
-    print(f"   → Lapa.ninja: {len(lapa_results)} URLs")
-    
-    # Combine all results
-    all_urls = []
-    all_urls.extend(ddg_results)
-    all_urls.extend(ph_results)
-    all_urls.extend(landingfolio_results)
-    all_urls.extend(lapa_results)
-    
-    print(f"   Total before dedup: {len(all_urls)}")
-    
-    # Normalize and deduplicate
-    unique_urls = deduplicate_urls(all_urls)
-    
-    print(f"   After dedup: {len(unique_urls)} unique URLs")
-    
-    return unique_urls[:count]
+async def search_async(keyword: str, count: int = TARGET_URLS) -> tuple[List[str], SearchReport]:
+    """Search all sources **in parallel**, deduplicate, and return URLs + health report."""
 
+    async def _run(name: str, coro) -> SourceResult:
+        try:
+            urls = await coro
+            return SourceResult(name=name, urls=urls)
+        except Exception as e:
+            return SourceResult(name=name, urls=[], error=str(e), ok=False)
+
+    results = await asyncio.gather(
+        _run("DuckDuckGo", search_duckduckgo(keyword, DDG_COUNT)),
+        _run("Product Hunt", search_producthunt(keyword, PH_COUNT)),
+        _run("Landingfolio", search_landingfolio(keyword, LF_COUNT)),
+        _run("Lapa.ninja", search_lapa(keyword, LAPA_COUNT)),
+    )
+
+    report = SearchReport(sources=list(results))
+
+    # Combine
+    all_urls: List[str] = []
+    for r in results:
+        all_urls.extend(r.urls)
+
+    report.total_before_dedup = len(all_urls)
+
+    # Deduplicate
+    unique = deduplicate_urls(all_urls)
+    report.total_after_dedup = len(unique)
+
+    return unique[:count], report
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
 
 def deduplicate_urls(urls: List[str]) -> List[str]:
-    """Remove duplicate URLs based on normalized domain.
-    
-    - Removes query parameters
-    - Normalizes protocol (prefer https)
-    - Keeps only one URL per domain
-    """
-    seen_domains = set()
-    unique_urls = []
-    
+    """One URL per domain, normalized."""
+    seen_domains: set[str] = set()
+    unique: List[str] = []
+
     for url in urls:
         normalized = normalize_url(url)
         if not normalized:
             continue
-            
         domain = get_domain(normalized)
-        if domain not in seen_domains:
+        if domain and domain not in seen_domains:
             seen_domains.add(domain)
-            unique_urls.append(normalized)
-    
-    return unique_urls
+            unique.append(normalized)
+
+    return unique
 
 
 def normalize_url(url: str) -> str:
-    """Normalize a URL for comparison."""
     try:
         parsed = urlparse(url)
-        
-        # Use https by default
-        scheme = 'https'
-        
-        # Remove www. prefix for consistency
+        scheme = "https"
         netloc = parsed.netloc.lower()
-        if netloc.startswith('www.'):
+        if netloc.startswith("www."):
             netloc = netloc[4:]
-        
-        # Remove query params and fragments for deduplication
-        # but keep the path
-        path = parsed.path.rstrip('/')
-        
+        path = parsed.path.rstrip("/")
         return f"{scheme}://{netloc}{path}"
     except Exception:
         return ""
 
 
 def get_domain(url: str) -> str:
-    """Extract domain from URL."""
     try:
-        parsed = urlparse(url)
-        return parsed.netloc.lower()
+        return urlparse(url).netloc.lower()
     except Exception:
         return ""

--- a/design_scout/search/landingfolio.py
+++ b/design_scout/search/landingfolio.py
@@ -1,99 +1,110 @@
-"""Landingfolio scraper - Landing page gallery"""
+"""Landingfolio scraper — uses Playwright to render JS content."""
+
+from typing import List
+from urllib.parse import urlparse
+
+try:
+    from playwright.async_api import async_playwright
+    HAS_PLAYWRIGHT = True
+except ImportError:
+    HAS_PLAYWRIGHT = False
 
 import httpx
-from typing import List
 import re
 
 
 async def search_landingfolio(keyword: str, count: int = 15) -> List[str]:
     """Search Landingfolio for landing page inspiration.
-    
-    Landingfolio showcases real landing pages organized by industry and style.
-    
-    Args:
-        keyword: Search term (e.g., "fintech", "saas")
-        count: Max URLs to return
-        
-    Returns:
-        List of website URLs
+
+    Landingfolio is JS-rendered — Playwright is preferred.
     """
-    encoded_keyword = keyword.replace(" ", "+")
-    url = f"https://www.landingfolio.com/?search={encoded_keyword}"
-    
+    if HAS_PLAYWRIGHT:
+        return await _search_playwright(keyword, count)
+    return await _search_httpx(keyword, count)
+
+
+async def _search_playwright(keyword: str, count: int) -> List[str]:
+    encoded = keyword.replace(" ", "+")
+    url = f"https://www.landingfolio.com/?search={encoded}"
+    urls: List[str] = []
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        try:
+            await page.goto(url, timeout=20000, wait_until="domcontentloaded")
+            await page.wait_for_timeout(3000)
+
+            hrefs = await page.eval_on_selector_all(
+                "a[href]",
+                "els => els.map(e => e.href)",
+            )
+
+            for href in hrefs:
+                if _is_valid_landing_url(href):
+                    if href not in urls:
+                        urls.append(href)
+        except Exception as e:
+            print(f"Landingfolio Playwright error: {e}")
+        finally:
+            await browser.close()
+
+    return urls[:count]
+
+
+async def _search_httpx(keyword: str, count: int) -> List[str]:
+    """Fallback — may get limited results."""
+    encoded = keyword.replace(" ", "+")
+    url = f"https://www.landingfolio.com/?search={encoded}"
     headers = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                       "AppleWebKit/537.36 (KHTML, like Gecko) "
+                       "Chrome/120.0.0.0 Safari/537.36",
     }
-    
     async with httpx.AsyncClient() as client:
         try:
-            response = await client.get(url, headers=headers, timeout=15.0, follow_redirects=True)
-            response.raise_for_status()
-            
-            urls = extract_landingfolio_urls(response.text)
+            resp = await client.get(url, headers=headers, timeout=15.0, follow_redirects=True)
+            resp.raise_for_status()
+            patterns = [
+                r'href="(https?://(?!(?:www\.)?landingfolio\.com)[^"]+)"',
+                r'data-url="(https?://[^"]+)"',
+                r'data-site="(https?://[^"]+)"',
+            ]
+            urls: List[str] = []
+            for pat in patterns:
+                for m in re.findall(pat, resp.text):
+                    if _is_valid_landing_url(m) and m not in urls:
+                        urls.append(m)
             return urls[:count]
-        except httpx.TimeoutException:
-            print(f"Landingfolio search timeout")
-            return []
-        except httpx.HTTPStatusError as e:
-            print(f"Landingfolio HTTP error: {e.response.status_code}")
-            return []
         except Exception as e:
-            print(f"Landingfolio search error: {e}")
+            print(f"Landingfolio httpx error: {e}")
             return []
 
 
-def extract_landingfolio_urls(html: str) -> List[str]:
-    """Extract website URLs from Landingfolio HTML."""
-    urls = []
-    
-    # Look for external links to actual landing pages
-    patterns = [
-        r'href="(https?://(?!(?:www\.)?landingfolio\.com)[^"]+)"',
-        r'data-url="(https?://[^"]+)"',
-        r'data-site="(https?://[^"]+)"',
-    ]
-    
-    for pattern in patterns:
-        matches = re.findall(pattern, html)
-        for match in matches:
-            if is_valid_landing_url(match):
-                if match not in urls:
-                    urls.append(match)
-    
-    return urls
+def _is_valid_landing_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower()
+    except Exception:
+        return False
 
+    if not url.startswith("http"):
+        return False
 
-def is_valid_landing_url(url: str) -> bool:
-    """Check if URL is likely a real landing page."""
-    excluded = [
-        'landingfolio.com',
-        'facebook.com',
-        'twitter.com',
-        'linkedin.com',
-        'instagram.com',
-        'youtube.com',
-        'pinterest.com',
-        'google.com',
-        'apple.com',
-        'cdn.',
-        'assets.',
-        '.js',
-        '.css',
-        '.png',
-        '.jpg',
-        '.gif',
-        '.svg',
-        '.woff',
-        '.ttf',
-        'fonts.googleapis',
-        'analytics',
-        'tracking',
+    blocked_domains = {
+        "landingfolio.com", "www.landingfolio.com",
+        "facebook.com", "twitter.com", "x.com",
+        "linkedin.com", "instagram.com", "youtube.com",
+        "pinterest.com", "google.com", "apple.com",
+        "fonts.googleapis.com",
+    }
+    if domain in blocked_domains:
+        return False
+
+    blocked_substrings = [
+        "cdn.", "assets.", "analytics", "tracking",
+        ".js", ".css", ".png", ".jpg", ".gif", ".svg",
+        ".woff", ".ttf", "cloudflare",
     ]
-    
     url_lower = url.lower()
-    for exc in excluded:
-        if exc in url_lower:
-            return False
-    
-    return url.startswith('http')
+    return not any(b in url_lower for b in blocked_substrings)

--- a/design_scout/search/lapa.py
+++ b/design_scout/search/lapa.py
@@ -1,10 +1,8 @@
-"""Lapa.ninja scraper - Landing page gallery (uses Playwright for JS rendering)"""
+"""Lapa.ninja scraper — uses Playwright for JS-rendered gallery pages."""
 
-import asyncio
 from typing import List
-import re
+from urllib.parse import urlparse
 
-# Try Playwright first, fall back to httpx
 try:
     from playwright.async_api import async_playwright
     HAS_PLAYWRIGHT = True
@@ -12,158 +10,121 @@ except ImportError:
     HAS_PLAYWRIGHT = False
 
 import httpx
+import re
 
 
 async def search_lapa(keyword: str, count: int = 15) -> List[str]:
     """Search Lapa.ninja for landing page inspiration.
-    
-    Lapa.ninja curates real landing pages from operating businesses.
-    Uses category pages which have better structure than search.
-    
-    Args:
-        keyword: Search term (e.g., "fintech", "saas")
-        count: Max URLs to return
-        
-    Returns:
-        List of website URLs
+
+    Lapa.ninja curates real landing pages. Content is JS-rendered,
+    so Playwright is strongly preferred.
     """
     if HAS_PLAYWRIGHT:
-        return await search_lapa_playwright(keyword, count)
-    else:
-        return await search_lapa_httpx(keyword, count)
+        return await _search_playwright(keyword, count)
+    return await _search_httpx(keyword, count)
 
 
-async def search_lapa_playwright(keyword: str, count: int = 15) -> List[str]:
-    """Use Playwright to handle JS-rendered content."""
-    # Try category page first (more reliable)
-    category_url = f"https://www.lapa.ninja/category/{keyword.lower().replace(' ', '-')}/"
+async def _search_playwright(keyword: str, count: int) -> List[str]:
+    slug = keyword.lower().replace(" ", "-")
+    category_url = f"https://www.lapa.ninja/category/{slug}/"
     search_url = f"https://www.lapa.ninja/search/?q={keyword.replace(' ', '+')}"
-    
-    urls = []
-    
+
+    urls: List[str] = []
+
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         page = await browser.new_page()
-        
         try:
-            # Try category page first
-            await page.goto(category_url, timeout=15000)
-            await page.wait_for_timeout(2000)  # Wait for JS
-            
-            # Extract links from the page
-            links = await page.eval_on_selector_all(
-                'a[href^="http"]',
-                'elements => elements.map(e => e.href)'
+            # Try category page first (better structured)
+            await page.goto(category_url, timeout=15000, wait_until="domcontentloaded")
+            await page.wait_for_timeout(2000)
+
+            # Lapa uses card links — target links that point to external sites
+            hrefs = await page.eval_on_selector_all(
+                "a[href]",
+                "els => els.map(e => e.href)",
             )
-            
-            for link in links:
-                if is_valid_landing_url(link):
-                    if link not in urls:
-                        urls.append(link)
-            
-            # If category didn't work, try search
+            for href in hrefs:
+                if _is_valid_landing_url(href) and href not in urls:
+                    urls.append(href)
+
+            # If category gave few results, also try search
             if len(urls) < 5:
-                await page.goto(search_url, timeout=15000)
+                await page.goto(search_url, timeout=15000, wait_until="domcontentloaded")
                 await page.wait_for_timeout(2000)
-                
-                links = await page.eval_on_selector_all(
-                    'a[href^="http"]',
-                    'elements => elements.map(e => e.href)'
+
+                hrefs = await page.eval_on_selector_all(
+                    "a[href]",
+                    "els => els.map(e => e.href)",
                 )
-                
-                for link in links:
-                    if is_valid_landing_url(link):
-                        if link not in urls:
-                            urls.append(link)
-                            
+                for href in hrefs:
+                    if _is_valid_landing_url(href) and href not in urls:
+                        urls.append(href)
+
         except Exception as e:
             print(f"Lapa.ninja Playwright error: {e}")
         finally:
             await browser.close()
-    
+
     return urls[:count]
 
 
-async def search_lapa_httpx(keyword: str, count: int = 15) -> List[str]:
-    """Fallback to httpx (may get limited results due to JS rendering)."""
-    # Try category URL format
-    category_url = f"https://www.lapa.ninja/category/{keyword.lower().replace(' ', '-')}/"
-    
+async def _search_httpx(keyword: str, count: int) -> List[str]:
+    """Fallback — limited results expected."""
+    slug = keyword.lower().replace(" ", "-")
+    url = f"https://www.lapa.ninja/category/{slug}/"
     headers = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                       "AppleWebKit/537.36 (KHTML, like Gecko) "
+                       "Chrome/120.0.0.0 Safari/537.36",
     }
-    
     async with httpx.AsyncClient() as client:
         try:
-            response = await client.get(category_url, headers=headers, timeout=15.0, follow_redirects=True)
-            response.raise_for_status()
-            
-            urls = extract_lapa_urls(response.text)
+            resp = await client.get(url, headers=headers, timeout=15.0, follow_redirects=True)
+            resp.raise_for_status()
+            patterns = [
+                r'href="(https?://(?!(?:www\.)?lapa\.ninja)[^"]+)"',
+                r'data-url="(https?://[^"]+)"',
+                r'data-href="(https?://[^"]+)"',
+            ]
+            urls: List[str] = []
+            for pat in patterns:
+                for m in re.findall(pat, resp.text):
+                    if _is_valid_landing_url(m) and m not in urls:
+                        urls.append(m)
             return urls[:count]
         except Exception as e:
             print(f"Lapa.ninja httpx error: {e}")
             return []
 
 
-def extract_lapa_urls(html: str) -> List[str]:
-    """Extract website URLs from Lapa.ninja HTML."""
-    urls = []
-    
-    # Look for external links
-    patterns = [
-        r'href="(https?://(?!(?:www\.)?lapa\.ninja)[^"]+)"',
-        r'data-url="(https?://[^"]+)"',
-        r'data-href="(https?://[^"]+)"',
-    ]
-    
-    for pattern in patterns:
-        matches = re.findall(pattern, html)
-        for match in matches:
-            if is_valid_landing_url(match):
-                if match not in urls:
-                    urls.append(match)
-    
-    return urls
+def _is_valid_landing_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower()
+    except Exception:
+        return False
 
+    if not url.startswith("http"):
+        return False
 
-def is_valid_landing_url(url: str) -> bool:
-    """Check if URL is likely a real landing page."""
-    excluded = [
-        'lapa.ninja',
-        'facebook.com',
-        'twitter.com',
-        'linkedin.com',
-        'instagram.com',
-        'youtube.com',
-        'pinterest.com',
-        'google.com',
-        'apple.com',
-        'producthunt.com',
-        'buymeacoffee.com',
-        'webflow.com',      # Promo links
-        'framer.link',      # Promo links
-        'try.webflow.com',  # Promo links
-        'cdn.',
-        'assets.',
-        '.js',
-        '.css',
-        '.png',
-        '.jpg',
-        '.gif',
-        '.svg',
-        '.woff',
-        '.ttf',
-        'fonts.googleapis',
-        'analytics',
-        'tracking',
-        'gravatar.com',
-        'cloudflare',
+    blocked_domains = {
+        "lapa.ninja", "www.lapa.ninja",
+        "facebook.com", "twitter.com", "x.com",
+        "linkedin.com", "instagram.com", "youtube.com",
+        "pinterest.com", "google.com", "apple.com",
+        "producthunt.com", "buymeacoffee.com",
+        "fonts.googleapis.com",
+        "webflow.com", "try.webflow.com",
+    }
+    if domain in blocked_domains:
+        return False
+
+    blocked_substrings = [
+        "cdn.", "assets.", "analytics", "tracking",
+        "framer.link",
+        ".js", ".css", ".png", ".jpg", ".gif", ".svg",
+        ".woff", ".ttf", "cloudflare", "gravatar.com",
     ]
-    
     url_lower = url.lower()
-    for exc in excluded:
-        if exc in url_lower:
-            return False
-    
-    return url.startswith('http')
+    return not any(b in url_lower for b in blocked_substrings)

--- a/design_scout/search/producthunt.py
+++ b/design_scout/search/producthunt.py
@@ -1,108 +1,112 @@
-"""Product Hunt scraper - Find trending products and their landing pages"""
+"""Product Hunt scraper — uses Playwright to render JS-heavy SPA."""
+
+from typing import List
+from urllib.parse import urlparse
+
+try:
+    from playwright.async_api import async_playwright
+    HAS_PLAYWRIGHT = True
+except ImportError:
+    HAS_PLAYWRIGHT = False
 
 import httpx
-from typing import List
-import re
 
 
 async def search_producthunt(keyword: str, count: int = 15) -> List[str]:
     """Search Product Hunt for product landing pages.
-    
-    Product Hunt showcases new tech products with links to their websites.
-    Great for finding real, operating startup landing pages.
-    
-    Args:
-        keyword: Search term (e.g., "fintech", "saas")
-        count: Max URLs to return
-        
-    Returns:
-        List of website URLs (not producthunt.com links)
+
+    Product Hunt is a React SPA — httpx alone cannot extract links.
+    Falls back to httpx if Playwright is unavailable (likely 0 results).
     """
-    encoded_keyword = keyword.replace(" ", "+")
-    url = f"https://www.producthunt.com/search?q={encoded_keyword}"
-    
+    if HAS_PLAYWRIGHT:
+        return await _search_playwright(keyword, count)
+    return await _search_httpx(keyword, count)
+
+
+async def _search_playwright(keyword: str, count: int) -> List[str]:
+    encoded = keyword.replace(" ", "+")
+    url = f"https://www.producthunt.com/search?q={encoded}"
+    urls: List[str] = []
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        try:
+            await page.goto(url, timeout=20000, wait_until="domcontentloaded")
+            # Wait for search results to render
+            await page.wait_for_timeout(3000)
+
+            # Product Hunt product cards link to /posts/xxx with an external
+            # "visit" link, or show the product URL in data attributes.
+            # Strategy: grab all <a> hrefs, then keep external ones.
+            hrefs = await page.eval_on_selector_all(
+                "a[href]",
+                "els => els.map(e => e.href)",
+            )
+
+            for href in hrefs:
+                if _is_external_product_url(href):
+                    if href not in urls:
+                        urls.append(href)
+        except Exception as e:
+            print(f"Product Hunt Playwright error: {e}")
+        finally:
+            await browser.close()
+
+    return urls[:count]
+
+
+async def _search_httpx(keyword: str, count: int) -> List[str]:
+    """Fallback — unlikely to yield results for this SPA site."""
+    encoded = keyword.replace(" ", "+")
+    url = f"https://www.producthunt.com/search?q={encoded}"
     headers = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                       "AppleWebKit/537.36 (KHTML, like Gecko) "
+                       "Chrome/120.0.0.0 Safari/537.36",
     }
-    
     async with httpx.AsyncClient() as client:
         try:
-            response = await client.get(url, headers=headers, timeout=15.0, follow_redirects=True)
-            response.raise_for_status()
-            
-            urls = extract_producthunt_urls(response.text)
-            return urls[:count]
-        except httpx.TimeoutException:
-            print(f"Product Hunt search timeout")
-            return []
-        except httpx.HTTPStatusError as e:
-            print(f"Product Hunt HTTP error: {e.response.status_code}")
-            return []
+            resp = await client.get(url, headers=headers, timeout=15.0, follow_redirects=True)
+            resp.raise_for_status()
+            # Best-effort: look for JSON-embedded URLs
+            import re
+            pattern = r'"(https?://(?!(?:www\.)?producthunt\.com)[^"]+)"'
+            matches = re.findall(pattern, resp.text)
+            return [m for m in matches if _is_external_product_url(m)][:count]
         except Exception as e:
-            print(f"Product Hunt search error: {e}")
+            print(f"Product Hunt httpx error: {e}")
             return []
 
 
-def extract_producthunt_urls(html: str) -> List[str]:
-    """Extract external website URLs from Product Hunt HTML."""
-    urls = []
-    
-    # Product Hunt links to actual product websites
-    # Look for external links that aren't producthunt.com
-    patterns = [
-        r'href="(https?://(?!(?:www\.)?producthunt\.com)[^"]+)"',
-        r'data-href="(https?://[^"]+)"',
-        r'"website":\s*"(https?://[^"]+)"',
-        r'"url":\s*"(https?://(?!(?:www\.)?producthunt\.com)[^"]+)"',
-    ]
-    
-    for pattern in patterns:
-        matches = re.findall(pattern, html)
-        for match in matches:
-            if is_valid_product_url(match):
-                if match not in urls:
-                    urls.append(match)
-    
-    return urls
+def _is_external_product_url(url: str) -> bool:
+    """Keep real product websites, filter noise."""
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower()
+    except Exception:
+        return False
 
+    if not url.startswith("http"):
+        return False
 
-def is_valid_product_url(url: str) -> bool:
-    """Check if URL is likely a real product website."""
-    excluded = [
-        'producthunt.com',
-        'facebook.com',
-        'twitter.com',
-        'linkedin.com',
-        'instagram.com',
-        'youtube.com',
-        'pinterest.com',
-        'google.com',
-        'apple.com',
-        'cdn.',
-        'assets.',
-        '.js',
-        '.css',
-        '.png',
-        '.jpg',
-        '.gif',
-        '.svg',
-        '.woff',
-        '.ttf',
-        'fonts.googleapis',
-        'analytics',
-        'tracking',
-        'gravatar.com',
-        'cloudflare',
-        'stripe.com',
-        'intercom.io',
-        'crisp.chat',
-        'hotjar.com',
+    blocked_domains = {
+        "producthunt.com", "www.producthunt.com",
+        "facebook.com", "twitter.com", "x.com",
+        "linkedin.com", "instagram.com", "youtube.com",
+        "pinterest.com", "google.com", "apple.com",
+        "github.com", "gravatar.com",
+        "fonts.googleapis.com", "cdn.jsdelivr.net",
+    }
+    if domain in blocked_domains:
+        return False
+
+    blocked_substrings = [
+        "cdn.", "assets.", "analytics", "tracking",
+        ".js", ".css", ".png", ".jpg", ".gif", ".svg",
+        ".woff", ".ttf", "cloudflare", "stripe.com",
+        "intercom.io", "crisp.chat", "hotjar.com",
+        "sentry.io", "segment.com",
     ]
-    
     url_lower = url.lower()
-    for exc in excluded:
-        if exc in url_lower:
-            return False
-    
-    return url.startswith('http')
+    return not any(b in url_lower for b in blocked_substrings)


### PR DESCRIPTION
## Summary

- **並行搜尋**: 4 個來源改用 `asyncio.gather` 同時跑（原本是序列，慢 4 倍）
- **SPA 來源修復**: Product Hunt / Landingfolio / Lapa.ninja 改用 Playwright 渲染（httpx 抓不到 SPA 內容）
- **健康報告**: 搜尋完顯示每個來源狀態，全失敗時提早退出並給明確訊息
- **截圖改善**: `networkidle` → `domcontentloaded`（更快更穩）+ 失敗自動重試 2 次
- **並行評分**: AI 評分改用 `asyncio.gather`（原本是 for loop 逐一跑）
- **快取機制**: 新增 `cache.py`，同 URL 不重複截圖/評分，重跑秒完
- **URL 清單模式**: 新增 `--urls file.txt` 跳過搜尋，直接指定網站
- **`.gitignore`**: 加入 Python cache 和 egg-info

## 改動目的

讓這個工具能在無人值守的情況下被 agent 自動呼叫：給方向就跑完全程，不需要人為介入。

## Test plan

- [x] Unit tests: URL normalize / dedup / SearchReport / Cache / format_result / URL file reader（全部通過）
- [ ] 本機 end-to-end: `design-scout "fintech dashboard" --no-score`
- [ ] 本機 end-to-end: `design-scout --urls sites.txt`
- [ ] 本機 AI 評分: 設定 API key 後跑完整流程

https://claude.ai/code/session_01HgFM5m7X3Tet4MqhVhv3Ee